### PR TITLE
fix range

### DIFF
--- a/rfc4122.js
+++ b/rfc4122.js
@@ -96,10 +96,10 @@ class RFC4122 {
 	}
 
 	v4f () {
-		let d0 = this.prng.random() * 0xffffffff|0,
-			d1 = this.prng.random() * 0xffffffff|0,
-			d2 = this.prng.random() * 0xffffffff|0,
-			d3 = this.prng.random() * 0xffffffff|0;
+		let d0 = this.prng.random() * 0x100000000|0,
+			d1 = this.prng.random() * 0x100000000|0,
+			d2 = this.prng.random() * 0x100000000|0,
+			d3 = this.prng.random() * 0x100000000|0;
 
 		return byteToHex[d0 & 0xff] +              byteToHex[d0 >> 8 & 0xff] +  byteToHex[d0 >> 16 & 0xff] + byteToHex[d0 >> 24 & 0xff] + '-' +
 			   byteToHex[d1 & 0xff] +              byteToHex[d1 >> 8 & 0xff] +  '-' +


### PR DESCRIPTION
Math.random() [gives a values in range \[0, 1)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random), that's why previous version never return 0xFF in 4 places. Example:
```
( 0.9999999999999999 * 0xffffffff ) & 0xff
```
gives 254 but must give 255 to fill the full range of possible variations. Also you can check that 0.9999999999999999 it is last number before 1 in console.
